### PR TITLE
Publish package to PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
 
     steps:
       - name: Check out repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Check the built packages
         run: python -m twine check dist/*
-
+        
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          username: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          username: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Build and publish to PyPI
+
+on:
+  workflow_dispatch:
+
+  release:
+    types: [created]
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build source and wheel distributions
+        run: python -m build
+
+      - name: Check the built packages
+        run: python -m twine check dist/*
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
       contents: read
       id-token: write
 
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -34,7 +33,5 @@ jobs:
       - name: Check the built packages
         run: python -m twine check dist/*
         
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ['Prospect',
 classifiers  = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering :: Agricultural Science",
+        "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pyPro4SAIL"
+name = "p4SAIL-test-marie"
 version = "1.5"
 description = "Vectorized vesions of the ProspectD and 4SAIL Radiative Transfer Models for simulating the transmission of radiation in leaves and canopies"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "p4sail-test-marie"
+name = "pyPro4SAIL"
 version = "1.5.1"
 description = "Vectorized vesions of the ProspectD and 4SAIL Radiative Transfer Models for simulating the transmission of radiation in leaves and canopies"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "p4sail-test-marie"
-version = "1.5"
+version = "1.5.1"
 description = "Vectorized vesions of the ProspectD and 4SAIL Radiative Transfer Models for simulating the transmission of radiation in leaves and canopies"
 authors = [
     { name = "Héctor Nieto", email = "hector.nieto@csic.es" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "p4SAIL-test-marie"
+name = "p4sail-test-marie"
 version = "1.5"
 description = "Vectorized vesions of the ProspectD and 4SAIL Radiative Transfer Models for simulating the transmission of radiation in leaves and canopies"
 authors = [


### PR DESCRIPTION
I have added a pipeline to Publish package to PyPI, it works the following way:
- It runs when you create a new release on github, or it can be triggered manually
- It uses the version from pyproject.toml, so you need to bump this before making a new release
- Can only publish versions that are not already published

In order to publish you first need to create a project on https://pypi.org/. This is free, so you simply need to
1.  Create a user account
2.  Under "publishing" add a new pending publisher. Here you need to fill in the repo that will be publishing to the package:
> - PyPI Project Name: pypro4sail
> - Owner: hectornieto
> - Repository name: pypro4sail
>- Workflow name: publish.yml